### PR TITLE
application/json Content-Type and correct Content-Length Calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,8 +134,8 @@ class Request extends EventEmitter {
     }
 
     json(object) {
-        const data = qs.stringify(object);
-        return this.headers({"Content-Type": "x-www-form-urlencoded", "Content-Length": data.length}).send(data);
+        const data = new Buffer(JSON.stringify(object));
+        return this.headers({"Content-Type": "application/json", "Content-Length": data.byteLength}).send(data);
     }
 }
 


### PR DESCRIPTION
Seems the original `.json` method is more like a form submission. This corrects it to be according to its name.
