### PR TITLE
Better typing + large file support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,30 +13,30 @@ declare module "es6-request" {
     
     type BodyType = string | Buffer;
 
-    class ES6Request {
+    class ES6Request extends stream.Duplex {
         req: http.ClientRequest;
 
-        headers(obj: http.OutgoingHttpHeaders): ES6Request;
-        header(key: string, value: number | string | string[] | undefined): ES6Request;
-        authBasic(username: string, password: string): ES6Request;
-        authBearer(bearer: string): ES6Request;
-        options(obj: Options): ES6Request;
-        option(key: string, value: any): ES6Request;
-        query(key: string, value: string): ES6Request;
-        query(params: object): ES6Request;
-        start(): ES6Request;
+        headers(obj: http.OutgoingHttpHeaders): this;
+        header(key: string, value: number | string | string[] | undefined): this;
+        authBasic(username: string, password: string): this;
+        authBearer(bearer: string): this;
+        options(obj: Options): this;
+        option(key: string, value: any): this;
+        query(key: string, value: string): this;
+        query(params: object): this;
+        start(): this;
         then(onSuccess?: (data: [string | Buffer, http.IncomingMessage]) => any, onFailure?: (err: Error) => any): Promise<any>;
         catch(onFailure?: (err: Error) => any): Promise<any>;
-        destroy(error?: Error): ES6Request;
+        destroy(error?: Error): this;
         perform(): Promise<[string | Buffer, http.IncomingMessage]>;
         perform<T extends BodyType>(): Promise<[T, http.IncomingMessage]>;
-        on(event: "error", listener: (err: Error) => void): ES6Request;
-        on(event: "data", listener: (chunk: Buffer) => void): ES6Request;
-        on(event: "progress", listener: (progress: number, current: number, total: number) => void): ES6Request;
-        on(event: "end", listener: () => void): ES6Request;
-        on(event: "close", listener: () => void): ES6Request;
-        write(chunk: string | Buffer, encoding?: string, callback?: Function): ES6Request;
-        pipe(dest: stream.Writable, opt?: object): ES6Request;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "data", listener: (chunk: Buffer) => void): this;
+        on(event: "progress", listener: (progress: number, current: number, total: number) => void): this;
+        on(event: "end", listener: () => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
+        pipe(dest: stream.Writable, opt?: object): this;
         send(body: string | Buffer, encoding?: string, callback?: Function): Promise<any>;
         sendForm(form: object): Promise<any>;
         sendMultipart(form: object | null, files: object | null, filesFieldNameFormat?: string, encoding?: string): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,13 +4,18 @@ declare module "es6-request" {
 
     interface CustomOptions {
         bodyAsBuffer?: boolean;
+        returnBody?: boolean;
     }
 
     interface Options extends http.ClientRequestArgs {
         custom?: CustomOptions;
     }
+    
+    type BodyType = string | Buffer;
 
     class ES6Request {
+        req: http.ClientRequest;
+
         headers(obj: http.OutgoingHttpHeaders): ES6Request;
         header(key: string, value: number | string | string[] | undefined): ES6Request;
         authBasic(username: string, password: string): ES6Request;
@@ -23,7 +28,13 @@ declare module "es6-request" {
         then(onSuccess?: (data: [string | Buffer, http.IncomingMessage]) => any, onFailure?: (err: Error) => any): Promise<any>;
         catch(onFailure?: (err: Error) => any): Promise<any>;
         destroy(error?: Error): ES6Request;
-        perform(): Promise<any>;
+        perform(): Promise<[string | Buffer, http.IncomingMessage]>;
+        perform<T extends BodyType>(): Promise<[T, http.IncomingMessage]>;
+        on(event: "error", listener: (err: Error) => void): ES6Request;
+        on(event: "data", listener: (chunk: Buffer) => void): ES6Request;
+        on(event: "progress", listener: (progress: number, current: number, total: number) => void): ES6Request;
+        on(event: "end", listener: () => void): ES6Request;
+        on(event: "close", listener: () => void): ES6Request;
         write(chunk: string | Buffer, encoding?: string, callback?: Function): ES6Request;
         pipe(dest: stream.Writable, opt?: object): ES6Request;
         send(body: string | Buffer, encoding?: string, callback?: Function): Promise<any>;

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ class ES6Request extends stream.Duplex {
             method: method,
             headers: {},
             custom: {
-                bodyAsBuffer: false
+                bodyAsBuffer: false,
+                returnBody: true
             }
         }, options);
 
@@ -231,7 +232,9 @@ class ES6Request extends stream.Duplex {
 
                 res.on("data", chunk => {
                     this.emit("data", chunk);
-                    this.body.push(chunk);
+                    if (this._options.custom.returnBody) {
+                        this.body.push(chunk);
+                    }
                     if (!isNaN(responseLength)) {
                         curLength += chunk.byteLength;
                         this.emit("progress", curLength / responseLength);
@@ -241,10 +244,14 @@ class ES6Request extends stream.Duplex {
                 res.on("end", () => {
                     this.emit("end");
 
-                    if (this._options.custom.bodyAsBuffer) {
-                        resolve([Buffer.concat(this.body), res]);
+                    if (this._options.custom.returnBody) {
+                        if (this._options.custom.bodyAsBuffer) {
+                            resolve([Buffer.concat(this.body), res]);
+                        } else {
+                            resolve([Buffer.concat(this.body).toString(), res]);
+                        }
                     } else {
-                        resolve([Buffer.concat(this.body).toString(), res]);
+                        resolve([null, res]);
                     }
 
                     this.destroy();

--- a/index.js
+++ b/index.js
@@ -285,8 +285,7 @@ class ES6Request extends stream.Duplex {
             this.start();
         }
 
-        this.req.write(chunk, encoding, callback);
-        return this;
+        return this.req.write(chunk, encoding, callback);
     }
 
     pipe(dest, opt) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-request",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "HTTP Request library written in ES6 for Node.js",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
- Improving large file support by adding option to not store / return the body in the `.then()`, to prevent memory exceptions with large files
- Improving the types by extending `stream.Duplex` and strongly typing multiple methods