### PR TITLE
Bugfix sending body

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,7 +330,8 @@ class ES6Request extends stream.Duplex {
             throw new TypeError("Invalid type for argument \"callback\"");
         }
 
-        return this.write(body, encoding, callback).perform();
+        this.write(body, encoding, callback);
+        return this.perform();
     }
 
     sendForm(form) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-request",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "HTTP Request library written in ES6 for Node.js",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
`this.write()` no longer returns `this`, so `this.write().perform()` produces errors.